### PR TITLE
Fix Large PDFs being marked valid

### DIFF
--- a/pdfwebsite/views.py
+++ b/pdfwebsite/views.py
@@ -70,7 +70,7 @@ def isPdfValid(path):
 		reader=PdfFileReader(open(path,'rb'))
 		num_pages = reader.getNumPages()
 		if num_pages>100:
-			return True
+			return False
 
 		return True
 	except utils.PdfReadError:


### PR DESCRIPTION
Looks like there's a typo where pdfs over 100 pages are marked valid. Looks like this should return false insteaad.