### PR TITLE
Use a more secure way of generating a random file suffix.

### DIFF
--- a/pdfwebsite/views.py
+++ b/pdfwebsite/views.py
@@ -1,13 +1,13 @@
+import datetime
+import os
+import secrets
+import subprocess
+import urllib.parse
+
 from django.shortcuts import render
 from django.core.files.storage import FileSystemStorage
-from urllib.parse import urlparse
-import urllib.parse
-import subprocess
-import os
-import datetime
-import random
-import string
 from PyPDF2 import PdfFileWriter, PdfFileReader, utils
+
 from pdfwebsite.models import File
 
 
@@ -42,7 +42,12 @@ def processPDF(uploaded_file):
 	dirspot = os.getcwd()
 	dirspot=dirspot+fs.url(name)
 	now = datetime.datetime.now()
-	scan_name='Scan_'+str(now.year)+str(now.month)+str(now.day)+'_'+randomString()
+
+	# 8 bytes of randomness on the end of the path should be sufficient -
+	# it is more than can be brute-forced in any reasonable amount of time
+	# over the network, especially with the cleanup task removing files every
+	# hour.
+	scan_name='Scan_' + str(now.year) + str(now.month) + str(now.day) + '_' + secrets.token_urlsafe(8)
 	dirspot=urllib.parse.unquote(dirspot)
 	validate_file=isPdfValid(dirspot)
 	if validate_file:
@@ -78,8 +83,3 @@ def isPdfValid(path):
 		return False
 	else:
 		return True
-
-
-def randomString(stringLength=4):
-    letters = string.ascii_lowercase
-    return ''.join(random.choice(letters) for i in range(stringLength))


### PR DESCRIPTION
(Hi, me from HN again!)

Currently, filenames were being generated by appending four random lower-case digits. This meant that there were only 456976 possible prefixes, which is more than reasonable to brute-force, even with the hourly removal of files in the cron job. It is also using `random`, which is documented as *not* suitable for generating secure tokens.

In its place, we can use `secrets.token_urlsafe(8)`, which is 8 bytes of randomness, or 1.8446744e+19 possible filenames. I think this is sufficiently safe, especially with the cleanup task removing files every hour.

Bonus changes: I re-grouped and re-arranged (stdlib imports, then package imports, then local imports) the imports, and removed an unused one.