### PR TITLE
Fix a warning (and possible undesirable behaviour) in `cleanfiles` management command

### DIFF
--- a/pdfwebsite/management/commands/cleanfiles.py
+++ b/pdfwebsite/management/commands/cleanfiles.py
@@ -1,23 +1,22 @@
+import os
+from datetime import timedelta
+
 from django.core.management.base import BaseCommand
 from django.utils import timezone
-from django.core.files.storage import FileSystemStorage
-from urllib.parse import urlparse
-import os
-from pdfwebsite.models import File
-from datetime import datetime, timedelta
 
-#File will check DB and delete files older than 1 hour.
+from pdfwebsite.models import File
+
 
 class Command(BaseCommand):
-    help = 'Cleans old files'
+    help = 'Removes files that are more than an hour old'
 
     def handle(self, *args, **kwargs):
-        time_threshold = datetime.now() - timedelta(hours=1)
+        time_threshold = timezone.now() - timedelta(hours=1)
         results = File.objects.filter(date_posted__lt=time_threshold)
         for file in results:
-        	path=file.path
-        	try:
-        		os.remove(path)
-        	except OSError:
-        		pass
-        	file.delete()
+            path = file.path
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+            file.delete()


### PR DESCRIPTION
Previously, `manage.py cleanfiles` would give a warning about comparing naive datetimes with timezone-aware ones. It's actually possible that this would behave in unpredictable depending on local configuration and current timezone, but mostly warnings are annoying enough that it's always best to use `django.utils.timezone.now()` any time you're in Django-land.

Bonus changes: regroup & tidy up imports (I'm awful, I know) and fix some inconsistent indentation.