### PR TITLE
Dockerise converter. Extend script with config args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y ghostscript imagemagick
+
+RUN sed -i 's/rights="none" pattern="PDF"/rights="read|write" pattern="PDF"/' /etc/ImageMagick-6/policy.xml
+
+WORKDIR /app
+
+COPY scanned_pdf.sh ./
+
+CMD ./scanned_pdf.sh

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ Example:
 ./scanned_pdf.sh scan.pdf
 ```
 
+# Docker
+
+Run the script from a Docker container
+
+```
+docker-compose build
+docker-compose run --rm app ./scanned_pdf.sh -o output.pdf input.pdf
+```
 
 # Pending
 - Contact form for people to send any PDF that may have failed the conversion process to check

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.2'
+
+services:
+
+  app:
+    build: .
+    command: ./scanned_pdf.sh
+    volumes:
+      # Mounts the app code (".") into the container's "/app" folder:
+      - .:/app:delegated

--- a/scanned_pdf.sh
+++ b/scanned_pdf.sh
@@ -1,7 +1,41 @@
-#Make your PDF look scanned.
-#Idea from the post in HN. Make a Gist with the command code.
-#https://gist.github.com/jduckles/29a7c5b0b8f91530af5ca3c22b897e10
+#!/bin/bash
+
+# Make your PDF look scanned.
+# Idea from the post in HN. Make a Gist with the command code.
+# https://gist.github.com/jduckles/29a7c5b0b8f91530af5ca3c22b897e10
+set -e
+
+usage() {
+  cat << EOF
+Usage: $0 file.pdf
+
+OPTIONS:
+   -h     Show this message
+   -o     Output File (default: document_flat.pdf)
+EOF
+}
+
+OUTPUT_FILE="document_flat.pdf"
+
+while getopts "o:h?" OPTION; do
+  case $OPTION in
+    o) OUTPUT_FILE=$OPTARG;;
+    h|?) usage; exit 1 ;;
+  esac
+done
+
+shift $(($OPTIND - 1))
 INPUT_FILE=$1
-convert -density 150 ${INPUT_FILE} -colorspace gray -linear-stretch 3.5%x10% -blur 0x0.5 -attenuate 0.25 +noise Gaussian  -rotate 1.0  aux_output.pdf
-gs -dSAFER -dBATCH -dNOPAUSE -dNOCACHE -sDEVICE=pdfwrite -sColorConversionStrategy=LeaveColorUnchanged -dAutoFilterColorImages=true -dAutoFilterGrayImages=true -dDownsampleMonoImages=true -dDownsampleGrayImages=true -dDownsampleColorImages=true -sOutputFile=document_flat.pdf aux_output.pdf
-rm aux_output.pdf
+TMP_FILE=$(mktemp "/tmp/$(date +"%Y-%m-%d_%T_XXXXXX")")
+
+if [[ -z $1 ]]; then
+  usage;
+  exit 1
+fi
+
+echo "Converting to image (2-3 seconds per page)"
+convert -density 150 "${INPUT_FILE}" -colorspace gray -linear-stretch 3.5%x10% -blur 0x0.5 -attenuate 0.25 +noise Gaussian  -rotate 1.0 "${TMP_FILE}"
+
+echo "Generating ${OUTPUT_FILE}"
+gs -dSAFER -dBATCH -dNOPAUSE -dNOCACHE -sDEVICE=pdfwrite -sColorConversionStrategy=LeaveColorUnchanged -dAutoFilterColorImages=true -dAutoFilterGrayImages=true -dDownsampleMonoImages=true -dDownsampleGrayImages=true -dDownsampleColorImages=true -sOutputFile="${OUTPUT_FILE}" "${TMP_FILE}"
+rm "$TMP_FILE"


### PR DESCRIPTION
Adds a Dockerfile so that this script can be run without installing all the dependencies.

Extends the script to
 - use a unique tmp file each time
 - make the output file configurable
 - fail gracefully if no args supplied